### PR TITLE
Feature/if has enough services

### DIFF
--- a/lib/helpers/helpers-designr.js
+++ b/lib/helpers/helpers-designr.js
@@ -10,33 +10,30 @@
 var helpers = {
 
   /**
-   * {{ifHasEnoughServices}}
-   * Checks to see if there are enough services provided to show services blocks
+   * {{ifEnoughPagesWithProperty}}
+   * Checks to see if there are enough pages with a specific property provided
+   * to proceed with a given content block
    * @author: Cody Richmond <http://github.com/gdvsbp>
    *
-   * @param  {[type]} content [description]
+   * @param  {object} dataSet [the object being looked in]
+   * @param  {integer} min [minimum number needed to be considered successful]
+   * @param  {string} propertyName [the name of the property we're checking the value of]
+   * @param {string} desiredPropertyValue   [the value we wish for the above property to have]
    * @param  {[type]} options [description]
    * @return {[type]}         [description]
    *
-   * @example: {{ifSome this compare=that}}
+   * @example: {{#ifEnoughPagesWithProperty dataSet 3 "propertyName" "desiredPropertyValue"}}
    */
-  ifHasEnoughServices: function () {
-    var argLength = arguments.length - 1,
-      content = arguments[argLength],
-      minServices = arguments[ 1 ],
-      pageData = arguments[ 0 ],
-      success = false,
-      page;
-
-    for( page in pageData ) {
-      if( pageData[ page ].data.services === "1" ) {
-        if( --minServices === 0 ) {
-          return content.fn(this);
+  ifEnoughPagesWithProperty: function ( dataSet, min, propertyName, desiredPropertyValue, options ) {
+    for( var page in dataSet ) {
+      if( dataSet[ page ].data[ propertyName ] === desiredPropertyValue ) {
+        if( --min === 0 ) {
+          return options.fn(this);
         }
       }
     }
 
-    return content.inverse(this);
+    return options.inverse(this);
   }
 
 };

--- a/lib/helpers/helpers-designr.js
+++ b/lib/helpers/helpers-designr.js
@@ -1,0 +1,53 @@
+/**
+ * Handlebars Helpers: Misc. Helpers
+ * Copyright (c) 2013 Jon Schlinkert, Brian Woodward, contributors
+ * Licensed under the MIT License (MIT).
+ */
+'use strict';
+
+
+// The module to be exported
+var helpers = {
+
+  /**
+   * {{ifHasEnoughServices}}
+   * Checks to see if there are enough services provided to show services blocks
+   * @author: Cody Richmond <http://github.com/gdvsbp>
+   *
+   * @param  {[type]} content [description]
+   * @param  {[type]} options [description]
+   * @return {[type]}         [description]
+   *
+   * @example: {{ifSome this compare=that}}
+   */
+  ifHasEnoughServices: function () {
+    var argLength = arguments.length - 1,
+      content = arguments[argLength],
+      minServices = arguments[ 1 ],
+      pageData = arguments[ 0 ],
+      success = false,
+      page;
+
+    for( page in pageData ) {
+      if( pageData[ page ].data.services === "1" ) {
+        if( --minServices === 0 ) {
+          return content.fn(this);
+        }
+      }
+    }
+
+    return content.inverse(this);
+  }
+
+};
+
+// Export helpers
+module.exports.register = function (Handlebars, options) {
+  options = options || {};
+
+  for (var helper in helpers) {
+    if (helpers.hasOwnProperty(helper)) {
+      Handlebars.registerHelper(helper, helpers[helper]);
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "handlebars-helpers",
   "description": "120+ Handlebars helpers in ~20 categories, for Assemble, YUI, Ghost or any Handlebars project. Includes helpers like {{i18}}, {{markdown}}, {{relative}}, {{extend}}, {{moment}}, and so on.",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "homepage": "https://github.com/assemble/handlebars-helpers",
   "author": {
     "name": "Assemble",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "handlebars-helpers",
   "description": "120+ Handlebars helpers in ~20 categories, for Assemble, YUI, Ghost or any Handlebars project. Includes helpers like {{i18}}, {{markdown}}, {{relative}}, {{extend}}, {{moment}}, and so on.",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "homepage": "https://github.com/assemble/handlebars-helpers",
   "author": {
     "name": "Assemble",


### PR DESCRIPTION
Need to be able to toggle the whole services block off if there aren't enough services. Due to the structure of the page data, we need to be able to dive into it to make this determination. This loop allows us to do so, and it's generic enough to use for any number of other group-of-page type of stuff as well.
